### PR TITLE
Added UseFullPath parameter to WriteItemsToFile

### DIFF
--- a/src/WriteItemsToFile/WriteItemsToFile.targets
+++ b/src/WriteItemsToFile/WriteItemsToFile.targets
@@ -31,6 +31,7 @@
 	<UsingTask TaskName="WriteItemsToFile" TaskFactory="CodeTaskFactory" AssemblyFile="$(CodeTaskAssembly)" Condition="'$(CodeTaskAssembly)' != ''">
 		<ParameterGroup>
 			<IncludeMetadata ParameterType="System.Nullable`1[[System.Boolean]]" />
+			<UseFullPath ParameterType="System.Boolean" />
 			<Items ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
 			<ItemName />
 			<File ParameterType="Microsoft.Build.Framework.ITaskItem" Required="true" />
@@ -66,7 +67,7 @@
 						metadataFromItem = item => Enumerable.Empty<XElement>();
 
 					Func<ITaskItem, XElement> itemFromElement = item => new XElement(XmlNs + itemName,
-						new XAttribute(IncludeAttributeName, item.ItemSpec), metadataFromItem(item));
+						new XAttribute(IncludeAttributeName, UseFullPath ? item.GetMetadata("FullPath") : item.ItemSpec), metadataFromItem(item));
 
 					var document = new XDocument(
 						new XElement(ProjectElementName,


### PR DESCRIPTION
Allows to override the default ItemSpec of the items with the FullPath metadata.