### PR TITLE
Add VSIX manifest identity version

### DIFF
--- a/src/ThisAssembly.Vsix/build/MSBuilder.ThisAssembly.Vsix.cs.pp
+++ b/src/ThisAssembly.Vsix/build/MSBuilder.ThisAssembly.Vsix.cs.pp
@@ -4,6 +4,7 @@
 
 #if ADDMETADATA
 [assembly: System.Reflection.AssemblyMetadata("Vsix.Identifier", RootNamespace.ThisAssembly.Vsix.Identifier)]
+[assembly: System.Reflection.AssemblyMetadata("Vsix.Version", RootNamespace.ThisAssembly.Vsix.Version)]
 [assembly: System.Reflection.AssemblyMetadata("Vsix.Name", RootNamespace.ThisAssembly.Vsix.Name)]
 [assembly: System.Reflection.AssemblyMetadata("Vsix.Description", RootNamespace.ThisAssembly.Vsix.Description)]
 [assembly: System.Reflection.AssemblyMetadata("Vsix.Author", RootNamespace.ThisAssembly.Vsix.Author)]
@@ -20,6 +21,9 @@ namespace _RootNamespace_
     {
       /// <summary>Identifier: $VsixID$</summary>
       public const string Identifier = "$VsixID$";
+
+      /// <summary>Version: $VsixVersion$</summary>
+      public const string Version = "$VsixVersion$";
           
       /// <summary>Name: $VsixName$</summary>
       public const string Name = "$VsixName$";

--- a/src/ThisAssembly.Vsix/build/MSBuilder.ThisAssembly.Vsix.targets
+++ b/src/ThisAssembly.Vsix/build/MSBuilder.ThisAssembly.Vsix.targets
@@ -48,6 +48,13 @@
 			<Output TaskParameter="Result" PropertyName="VsixID" />
 		</XmlPeek>
 
+		<XmlPeek Condition="'$(VsixVersion)' == ''" Namespaces="$(Vsix2010)" XmlInputPath="@(SourceVsixManifest)" Query="/vs:Vsix/vs:Identifier/@Version">
+			<Output TaskParameter="Result" PropertyName="VsixVersion" />
+		</XmlPeek>
+		<XmlPeek Condition="'$(VsixVersion)' == ''" Namespaces="$(Vsix2011)" XmlInputPath="@(SourceVsixManifest)" Query="/vs:PackageManifest/vs:Metadata/vs:Identity/@Version">
+			<Output TaskParameter="Result" PropertyName="VsixVersion" />
+		</XmlPeek>
+
 		<XmlPeek Condition="'$(VsixName)' == ''" Namespaces="$(Vsix2010)" XmlInputPath="@(SourceVsixManifest)" Query="/vs:Vsix/vs:Identifier/vs:Name/text()">
 			<Output TaskParameter="Result" PropertyName="VsixName" />
 		</XmlPeek>
@@ -97,6 +104,7 @@
 
 			<!-- Actual exposed values here -->
 			<_ThisVsixInfoContent>$(_ThisVsixInfoContent.Replace('$VsixID$', '$(VsixID)'))</_ThisVsixInfoContent>
+			<_ThisVsixInfoContent>$(_ThisVsixInfoContent.Replace('$VsixVersion$', '$(VsixVersion)'))</_ThisVsixInfoContent>
 			<_ThisVsixInfoContent>$(_ThisVsixInfoContent.Replace('$VsixName$', '$(VsixName)'))</_ThisVsixInfoContent>
 			<_ThisVsixInfoContent>$(_ThisVsixInfoContent.Replace('$VsixDescription$', '$(VsixDescription)'))</_ThisVsixInfoContent>
 			<_ThisVsixInfoContent>$(_ThisVsixInfoContent.Replace('$VsixAuthor$', '$(VsixAuthor)'))</_ThisVsixInfoContent>

--- a/src/ThisAssembly.Vsix/build/MSBuilder.ThisAssembly.Vsix.targets
+++ b/src/ThisAssembly.Vsix/build/MSBuilder.ThisAssembly.Vsix.targets
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<!--
 	==============================================================
-          Retrieves and exposes VSIX information
-		  
+					Retrieves and exposes VSIX information
+			
 	If the importing project has a C# or VB Language property, 
 	by default a ThisAssembly file/class will be generated 
 	containing assembly-level metadata for the VSIX information
@@ -13,9 +13,9 @@
 	Customization:
 	
 	$(ThisAssemblyNamespace): allows overriding the namespace
-							  for the ThisAssembly class.
-							  Defaults to the global namespace.
-			  
+								for the ThisAssembly class.
+								Defaults to the global namespace.
+				
 	==============================================================
 	-->
 
@@ -35,58 +35,58 @@
 	<Target Name="EnsureSourceVsixManifest" Condition="'@(SourceVsixManifest)' == ''">
 		<!-- Under VSSDK 15.0+, the FindSourceVsixManifest target is not run unless '$(CreateVsixContainer)' == 'true' -->
 		<FindVsixManifest ItemsToConsider="@(None)"
-						  ProjectName="$(MSBuildProjectName)">
+							ProjectName="$(MSBuildProjectName)">
 			<Output TaskParameter="VsixManifest" ItemName="SourceVsixManifest"/>
 		</FindVsixManifest>
 	</Target>
 	
-	<Target Name="VsixInfo" DependsOnTargets="FindSourceVsixManifest" Condition="Exists('@(SourceVsixManifest)')">
-		<XmlPeek Condition="'$(VsixID)' == ''" Namespaces="$(Vsix2010)" XmlInputPath="@(SourceVsixManifest)" Query="/vs:Vsix/vs:Identifier/@Id">
+	<Target Name="VsixInfo" AfterTargets="DetokenizeVsixManifestFile" Condition="Exists('$(IntermediateVsixManifest)')">
+		<XmlPeek Condition="'$(VsixID)' == ''" Namespaces="$(Vsix2010)" XmlInputPath="$(IntermediateVsixManifest)" Query="/vs:Vsix/vs:Identifier/@Id">
 			<Output TaskParameter="Result" PropertyName="VsixID" />
 		</XmlPeek>
-		<XmlPeek Condition="'$(VsixID)' == ''" Namespaces="$(Vsix2011)" XmlInputPath="@(SourceVsixManifest)" Query="/vs:PackageManifest/vs:Metadata/vs:Identity/@Id">
+		<XmlPeek Condition="'$(VsixID)' == ''" Namespaces="$(Vsix2011)" XmlInputPath="$(IntermediateVsixManifest)" Query="/vs:PackageManifest/vs:Metadata/vs:Identity/@Id">
 			<Output TaskParameter="Result" PropertyName="VsixID" />
 		</XmlPeek>
 
-		<XmlPeek Condition="'$(VsixVersion)' == ''" Namespaces="$(Vsix2010)" XmlInputPath="@(SourceVsixManifest)" Query="/vs:Vsix/vs:Identifier/@Version">
+		<XmlPeek Condition="'$(VsixVersion)' == ''" Namespaces="$(Vsix2010)" XmlInputPath="$(IntermediateVsixManifest)" Query="/vs:Vsix/vs:Identifier/@Version">
 			<Output TaskParameter="Result" PropertyName="VsixVersion" />
 		</XmlPeek>
-		<XmlPeek Condition="'$(VsixVersion)' == ''" Namespaces="$(Vsix2011)" XmlInputPath="@(SourceVsixManifest)" Query="/vs:PackageManifest/vs:Metadata/vs:Identity/@Version">
+		<XmlPeek Condition="'$(VsixVersion)' == ''" Namespaces="$(Vsix2011)" XmlInputPath="$(IntermediateVsixManifest)" Query="/vs:PackageManifest/vs:Metadata/vs:Identity/@Version">
 			<Output TaskParameter="Result" PropertyName="VsixVersion" />
 		</XmlPeek>
 
-		<XmlPeek Condition="'$(VsixName)' == ''" Namespaces="$(Vsix2010)" XmlInputPath="@(SourceVsixManifest)" Query="/vs:Vsix/vs:Identifier/vs:Name/text()">
+		<XmlPeek Condition="'$(VsixName)' == ''" Namespaces="$(Vsix2010)" XmlInputPath="$(IntermediateVsixManifest)" Query="/vs:Vsix/vs:Identifier/vs:Name/text()">
 			<Output TaskParameter="Result" PropertyName="VsixName" />
 		</XmlPeek>
-		<XmlPeek Condition="'$(VsixName)' == ''" Namespaces="$(Vsix2011)" XmlInputPath="@(SourceVsixManifest)" Query="/vs:PackageManifest/vs:Metadata/vs:DisplayName/text()">
+		<XmlPeek Condition="'$(VsixName)' == ''" Namespaces="$(Vsix2011)" XmlInputPath="$(IntermediateVsixManifest)" Query="/vs:PackageManifest/vs:Metadata/vs:DisplayName/text()">
 			<Output TaskParameter="Result" PropertyName="VsixName" />
 		</XmlPeek>
 
-		<XmlPeek Condition="'$(VsixDescription)' == ''" Namespaces="$(Vsix2010)" XmlInputPath="@(SourceVsixManifest)" Query="/vs:Vsix/vs:Identifier/vs:Description/text()">
+		<XmlPeek Condition="'$(VsixDescription)' == ''" Namespaces="$(Vsix2010)" XmlInputPath="$(IntermediateVsixManifest)" Query="/vs:Vsix/vs:Identifier/vs:Description/text()">
 			<Output TaskParameter="Result" PropertyName="VsixDescription" />
 		</XmlPeek>
-		<XmlPeek Condition="'$(VsixDescription)' == ''" Namespaces="$(Vsix2011)" XmlInputPath="@(SourceVsixManifest)" Query="/vs:PackageManifest/vs:Metadata/vs:Description/text()">
+		<XmlPeek Condition="'$(VsixDescription)' == ''" Namespaces="$(Vsix2011)" XmlInputPath="$(IntermediateVsixManifest)" Query="/vs:PackageManifest/vs:Metadata/vs:Description/text()">
 			<Output TaskParameter="Result" PropertyName="VsixDescription" />
 		</XmlPeek>
 
-		<XmlPeek Condition="'$(VsixAuthor)' == ''" Namespaces="$(Vsix2010)" XmlInputPath="@(SourceVsixManifest)" Query="/vs:Vsix/vs:Identifier/vs:Author/text()">
+		<XmlPeek Condition="'$(VsixAuthor)' == ''" Namespaces="$(Vsix2010)" XmlInputPath="$(IntermediateVsixManifest)" Query="/vs:Vsix/vs:Identifier/vs:Author/text()">
 			<Output TaskParameter="Result" PropertyName="VsixAuthor" />
 		</XmlPeek>
-		<XmlPeek Condition="'$(VsixAuthor)' == ''" Namespaces="$(Vsix2011)" XmlInputPath="@(SourceVsixManifest)" Query="/vs:PackageManifest/vs:Metadata/vs:Identity/@Publisher">
+		<XmlPeek Condition="'$(VsixAuthor)' == ''" Namespaces="$(Vsix2011)" XmlInputPath="$(IntermediateVsixManifest)" Query="/vs:PackageManifest/vs:Metadata/vs:Identity/@Publisher">
 			<Output TaskParameter="Result" PropertyName="VsixAuthor" />
 		</XmlPeek>
 	</Target>
 
-	<Target Name="VsixThisAssembly" DependsOnTargets="_VsixGenerateThisAssembly"
+	<Target Name="VsixThisAssembly" AfterTargets="_VsixGenerateThisAssembly"
 			Condition="'$(Language)' == 'C#' Or '$(Language)' == 'VB'">
 		<ItemGroup>
 			<Compile Include="$(ThisVsixInfoFile)" />
 		</ItemGroup>
 	</Target>
 
-	<Target Name="_VsixGenerateThisAssembly" DependsOnTargets="VsixInfo"
+	<Target Name="_VsixGenerateThisAssembly" AfterTargets="VsixInfo"
 			Condition="'$(Language)' == 'C#' Or '$(Language)' == 'VB'"
-			Inputs="@(SourceVsixManifest)" Outputs="$(ThisVsixInfoFile)">
+			Inputs="$(IntermediateVsixManifest)" Outputs="$(ThisVsixInfoFile)">
 
 		<PropertyGroup>
 			<_ThisVsixInfoContent>$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)MSBuilder.ThisAssembly.Vsix$(DefaultLanguageSourceExtension).pp'))</_ThisVsixInfoContent>

--- a/src/ThisAssembly.Vsix/build/MSBuilder.ThisAssembly.Vsix.vb.pp
+++ b/src/ThisAssembly.Vsix/build/MSBuilder.ThisAssembly.Vsix.vb.pp
@@ -3,6 +3,7 @@
 
 #If ADDMETADATA
 <Assembly: System.Reflection.AssemblyMetadata("Vsix.Identifier", Global.RootNamespace.ThisAssembly.Vsix.Identifier)>
+<Assembly: System.Reflection.AssemblyMetadata("Vsix.Version", Global.RootNamespace.ThisAssembly.Vsix.Version)>
 <Assembly: System.Reflection.AssemblyMetadata("Vsix.Name", Global.RootNamespace.ThisAssembly.Vsix.Name)>
 <Assembly: System.Reflection.AssemblyMetadata("Vsix.Description", Global.RootNamespace.ThisAssembly.Vsix.DEscription)>
 <Assembly: System.Reflection.AssemblyMetadata("Vsix.Author", Global.RootNamespace.ThisAssembly.Vsix.Author)>
@@ -18,6 +19,9 @@ Namespace Global
         Partial Public Class Vsix
             ''' <summary>Identifier: $VsixID$</summary>
             Public Const Identifier = "$VsixID$"
+
+            ''' <summary>Version: $VsixVersion$</summary>
+            Public Const Version = "$VsixVersion$"
 
             ''' <summary>Name: $VsixName$</summary>
             Public Const Name = "$VsixName$"

--- a/src/ThisAssembly.Vsix/build/MSBuilder.ThisAssembly.Vsix.vb.pp
+++ b/src/ThisAssembly.Vsix/build/MSBuilder.ThisAssembly.Vsix.vb.pp
@@ -5,7 +5,7 @@
 <Assembly: System.Reflection.AssemblyMetadata("Vsix.Identifier", Global.RootNamespace.ThisAssembly.Vsix.Identifier)>
 <Assembly: System.Reflection.AssemblyMetadata("Vsix.Version", Global.RootNamespace.ThisAssembly.Vsix.Version)>
 <Assembly: System.Reflection.AssemblyMetadata("Vsix.Name", Global.RootNamespace.ThisAssembly.Vsix.Name)>
-<Assembly: System.Reflection.AssemblyMetadata("Vsix.Description", Global.RootNamespace.ThisAssembly.Vsix.DEscription)>
+<Assembly: System.Reflection.AssemblyMetadata("Vsix.Description", Global.RootNamespace.ThisAssembly.Vsix.Description)>
 <Assembly: System.Reflection.AssemblyMetadata("Vsix.Author", Global.RootNamespace.ThisAssembly.Vsix.Author)>
 #End If
 


### PR DESCRIPTION
* Support for version in VSIX schema v1 [Link](https://msdn.microsoft.com/en-us/library/ee191547.aspx#Anchor_0)
* Support for version in VSIX schema v2 [Link](https://docs.microsoft.com/en-us/visualstudio/extensibility/vsix-extension-schema-2-0-reference#metadata-element)

* Fix spelling on VB "Vsix.Description" assembly attribute
